### PR TITLE
ユーザ周りのエンドポイントを一新

### DIFF
--- a/src/accounts/permissions.py
+++ b/src/accounts/permissions.py
@@ -1,0 +1,10 @@
+from rest_framework import permissions
+
+
+class IsOwnerOrReadOnly(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        """GETリクエストは通すがPOSTやPUTは所有者を確認する"""
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return request.user == obj.user

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -18,7 +18,6 @@ class Logout(LoginRequiredMixin, LogoutView):
 
 class UserViewSets(mixins.RetrieveModelMixin,
                    mixins.CreateModelMixin,
-                   mixins.UpdateModelMixin,
                    viewsets.GenericViewSet):
 
     """
@@ -27,9 +26,6 @@ class UserViewSets(mixins.RetrieveModelMixin,
 
     create:
         ユーザを作成するエンドポイント．未認証のユーザでも叩ける．
-
-    update:
-        ユーザのプロフィールを更新するエンドポイント．
     """
     queryset = models.User.objects.all()
     permission_classes = (permissions.IsAuthenticated, custom_permissions.IsOwnerOrReadOnly)

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView, LogoutView
+from rest_framework import viewsets, mixins, permissions
 from .forms import LoginForm
+from . import serializers, models
 
 
 class Login(LoginView):
@@ -12,3 +14,31 @@ class Login(LoginView):
 class Logout(LoginRequiredMixin, LogoutView):
     """ログアウトページ"""
     template_name = 'accounts/top.html'
+
+
+class UserViewSets(mixins.RetrieveModelMixin,
+                   mixins.CreateModelMixin,
+                   mixins.UpdateModelMixin,
+                   viewsets.GenericViewSet):
+
+    """
+    retrieve:
+        指定したユーザのプロフィールを取得するエンドポイント
+
+    create:
+        ユーザを作成するエンドポイント．未認証のユーザでも叩ける．
+
+    update:
+        ユーザのプロフィールを更新するエンドポイント．
+    """
+    queryset = models.User.objects.all()
+
+    def get_permissions(self):
+        if self.action == 'create':
+            self.permission_classes = [permissions.AllowAny]
+        return super(UserViewSets, self).get_permissions()
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return serializers.CreateUserSerializer
+        return serializers.UserSerializer

--- a/src/accounts/views.py
+++ b/src/accounts/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import LoginView, LogoutView
-from rest_framework import viewsets, mixins, permissions
+from rest_framework import viewsets, mixins, permissions, generics
 from .forms import LoginForm
 from . import serializers, models, permissions as custom_permissions
 
@@ -41,9 +41,7 @@ class UserViewSets(mixins.RetrieveModelMixin,
         return serializers.UserSerializer
 
 
-class MeViewSets(mixins.RetrieveModelMixin,
-                 mixins.UpdateModelMixin,
-                 viewsets.GenericViewSet):
+class MeViewSet(generics.RetrieveUpdateAPIView):
     """
     自分自身の情報を取得するエンドポイント
 

--- a/src/plan/mixins.py
+++ b/src/plan/mixins.py
@@ -102,11 +102,12 @@ class UserNestedListMixin(object):
         else:
             queryset = self.get_queryset().filter(user_id=int(user_pk)).all()
         queryset = self.filter_queryset(queryset)
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self._serialize(serializer_class, page, many=True)
-            return self.get_paginated_response(serializer.data)
-        serializer = self._serialize(queryset, page, many=True)
+        if request.version == 'v2':
+            page = self.paginate_queryset(queryset)
+            if page is not None:
+                serializer = self._serialize(serializer_class, page, many=True)
+                return self.get_paginated_response(serializer.data)
+        serializer = self._serialize(serializer_class, queryset, many=True)
         return Response(serializer.data)
 
 

--- a/src/plan/mixins.py
+++ b/src/plan/mixins.py
@@ -98,7 +98,7 @@ class UserNestedListMixin(object):
         :return:
         """
         if user_pk is None:
-            queryset = self.get_queryset()
+            queryset = self.get_queryset().filter(user_id=request.user.pk)
         else:
             queryset = self.get_queryset().filter(user_id=int(user_pk)).all()
         queryset = self.filter_queryset(queryset)
@@ -116,6 +116,8 @@ class UserNestedRetrieveMixin(object):
     """
 
     def retrieve(self, request, pk=None, user_pk=None, **kwargs):
+        if user_pk is None:
+            user_pk = request.user.pk
         comment = get_object_or_404(self.queryset, pk=pk, user_id=int(user_pk))
         serializer = self.get_serializer(comment)
         return Response(serializer.data)

--- a/src/plan/mixins.py
+++ b/src/plan/mixins.py
@@ -3,25 +3,25 @@ from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
 
 
-class NestedRetrieveMixin(object):
+class PlanNestedRetrieveMixin(object):
     """
     /plans/<plan_pk>/favs/<id>/ のようなネストされた要素の詳細をGETするmixin
     """
 
     def retrieve(self, request, pk=None, plan_pk=None, **kwargs):
-        comment = get_object_or_404(self.queryset, pk=pk, plan_id=plan_pk)
+        comment = get_object_or_404(self.queryset, pk=pk, plan_id=int(plan_pk))
         serializer = self.get_serializer(comment)
         return Response(serializer.data)
 
 
-class NestedDestroyMixin(object):
+class PlanNestedDestroyMixin(object):
     """
     /plans/<plan_pk>/favs/<id>/ のようなネストされた要素をDELETEする時のmixin
     """
 
     def destroy(self, request, pk=None, plan_pk=None, **kwargs):
         user = request.user
-        comment = get_object_or_404(self.get_queryset(), pk=pk, plan_id=plan_pk, user=user)
+        comment = get_object_or_404(self.get_queryset(), pk=pk, plan_id=int(plan_pk), user=user)
         self.perform_destroy(comment)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -29,7 +29,7 @@ class NestedDestroyMixin(object):
         instance.delete()
 
 
-class NestedListMixin(object):
+class PlanNestedListMixin(object):
     """
     /plans/<plan_pk>/favs/ のようなネストされた要素に対してリストを返す時のmixin
     """
@@ -59,7 +59,7 @@ class NestedListMixin(object):
         if plan_pk is None:
             queryset = self.get_queryset()
         else:
-            queryset = self.get_queryset().filter(plan_id=plan_pk).all()
+            queryset = self.get_queryset().filter(plan_id=int(plan_pk)).all()
         queryset = self.filter_queryset(queryset)
         if request.version == 'v2':
             page = self.paginate_queryset(queryset)
@@ -67,4 +67,55 @@ class NestedListMixin(object):
                 serializer = self._serialize(serializer_class, page, many=True)
                 return self.get_paginated_response(serializer.data)
         serializer = self._serialize(serializer_class, queryset, many=True)
+        return Response(serializer.data)
+
+
+class UserNestedListMixin(object):
+    """
+    /users/<user_pk>/favs/ のようなネストされた要素に対してリストを返す時のmixin
+    """
+    def _serialize(self, serializer_class, queryset, *args, **kwargs):
+        """
+        Serializerの指定があればそれで返す．無ければself.get_serializerする．
+        :param serializer_class: 使用するSerializerクラスを指定する
+        :param args: Serializerをインスタンス化する際の位置引数
+        :param kwargs: Serializerをインスタンス化する際のオプション引数
+        :return: インスタンス化されたSerializer
+        """
+        if serializer_class is None:
+            if 'context' in kwargs.keys():
+                kwargs.pop('context')
+            return self.get_serializer(queryset, *args, **kwargs)
+        return serializer_class(queryset, *args, context=self.get_serializer_context(), **kwargs)
+
+    def list(self, request, user_pk=None, serializer_class=None, **kwargs):
+        """
+        user_pkでフィルタリングしてレスポンスを返す
+        :param request: ユーザのリクエストオブジェクト
+        :param user_pk: フィルタ対象のPlanのPrimary Key
+        :param serializer_class: 使用するSerializer．デフォルトはself.serializerになる．
+        :param kwargs: その他オプション
+        :return:
+        """
+        if user_pk is None:
+            queryset = self.get_queryset()
+        else:
+            queryset = self.get_queryset().filter(user_id=int(user_pk)).all()
+        queryset = self.filter_queryset(queryset)
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self._serialize(serializer_class, page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self._serialize(queryset, page, many=True)
+        return Response(serializer.data)
+
+
+class UserNestedRetrieveMixin(object):
+    """
+    /users/<user_pk>/favs/<id>/ のようなネストされた要素の詳細をGETするmixin
+    """
+
+    def retrieve(self, request, pk=None, user_pk=None, **kwargs):
+        comment = get_object_or_404(self.queryset, pk=pk, user_id=int(user_pk))
+        serializer = self.get_serializer(comment)
         return Response(serializer.data)

--- a/src/plan/tests/base.py
+++ b/src/plan/tests/base.py
@@ -33,7 +33,6 @@ class V1TestCase(APITestCase):
         # Users
         self.user_path = self.path_prefix + 'users/'
         self.user_detail_path = self.user_path + '{}/'
-        self.user_fav_path = self.user_detail_path + 'favs/'
         self.user_plan_path = self.user_detail_path + 'plans/'
 
     def setUp(self):

--- a/src/plan/tests/base.py
+++ b/src/plan/tests/base.py
@@ -7,22 +7,34 @@ from plan.models import Comment, Plan, Fav
 from .data import plan_data, comment_data, user_data, report_data
 
 
-class BaseTestCase(APITestCase):
+class V1TestCase(APITestCase):
 
     path_prefix = '/api/v1/'
-    # Plan
-    plan_path = path_prefix + 'plans/'
-    plan_detail_path = plan_path + '{}/'
-    # Fav
-    fav_path = plan_detail_path + 'favs/'
-    fav_detail_path = fav_path + '{}/'
-    fav_me_path = fav_path + 'me/'
-    # Comment
-    comment_path = plan_detail_path + 'comments/'
-    comment_detail_path = comment_path + '{}/'
-    # Report
-    report_path = plan_detail_path + 'reports/'
-    report_detail_path = report_path + '{}/'
+
+    def __init__(self, *args, **kwargs):
+        super(V1TestCase, self).__init__(*args, **kwargs)
+        # Plan
+        self.plan_path = self.path_prefix + 'plans/'
+        self.plan_detail_path = self.plan_path + '{}/'
+        # Fav
+        self.fav_path = self.plan_detail_path + 'favs/'
+        self.fav_detail_path = self.fav_path + '{}/'
+        self.fav_me_path = self.fav_path + 'me/'
+        # Comment
+        self.comment_path = self.plan_detail_path + 'comments/'
+        self.comment_detail_path = self.comment_path + '{}/'
+        # Report
+        self.report_path = self.plan_detail_path + 'reports/'
+        self.report_detail_path = self.report_path + '{}/'
+        # Me
+        self.me_path = self.path_prefix + 'me/'
+        self.my_fav_path = self.me_path + 'favs/'
+        self.my_plan_path = self.me_path + 'plans/'
+        # Users
+        self.user_path = self.path_prefix + 'users/'
+        self.user_detail_path = self.user_path + '{}/'
+        self.user_fav_path = self.user_detail_path + 'favs/'
+        self.user_plan_path = self.user_detail_path + 'plans/'
 
     def setUp(self):
         self.user_data = copy.deepcopy(user_data)
@@ -35,7 +47,7 @@ class BaseTestCase(APITestCase):
         self.plan_id = self.plan_res.data['pk']
 
     def tearDown(self):
-        super(BaseTestCase, self).tearDown()
+        super(V1TestCase, self).tearDown()
         Comment.objects.all().delete()
         Fav.objects.all().delete()
         Plan.objects.all().delete()
@@ -49,3 +61,7 @@ class BaseTestCase(APITestCase):
         payload = jwt_payload_handler(user)
         token = jwt_encode_handler(payload)
         self.client.credentials(HTTP_AUTHORIZATION="JWT " + token)
+
+
+class V2TestCase(V1TestCase):
+    path_prefix = '/api/v2/'

--- a/src/plan/tests/test_nested_comment.py
+++ b/src/plan/tests/test_nested_comment.py
@@ -5,7 +5,7 @@ from .base import V1TestCase
 class CommentTestCase(V1TestCase):
 
     def test_post(self):
-        """POST /plan/plans/<id>/comments/: コメント作成テスト"""
+        """POST /plans/<id>/comments/: コメント作成テスト"""
         res = self.client.post(self.comment_path.format(self.plan_id), data=self.comment_data[0], format="json")
         self.assertEqual(201, res.status_code)
         self.assertEqual(self.comment_data[0]['text'], res.data['text'])
@@ -13,7 +13,7 @@ class CommentTestCase(V1TestCase):
         self.assertEqual(self.user.username, res.data['user']['username'])
 
     def test_get_list(self):
-        """GET /plan/plans/<id>/comments/: コメント一覧取得テスト"""
+        """GET /plans/<id>/comments/: コメント一覧取得テスト"""
         comment = Comment.objects.create(user=self.user, plan_id=self.plan_id, **self.comment_data[0])
         res = self.client.get(self.comment_path.format(self.plan_id), data={}, format="json")
         self.assertEqual(200, res.status_code)
@@ -26,7 +26,7 @@ class CommentTestCase(V1TestCase):
         self.assertTrue(comment.pk in comments_list)
 
     def test_destroy(self):
-        """DELETE /plan/plans/<id>/comments/<id>/: コメント削除テスト"""
+        """DELETE /plans/<id>/comments/<id>/: コメント削除テスト"""
         comment = Comment.objects.create(user=self.user, plan_id=self.plan_id, **self.comment_data[0])
         res = self.client.delete(self.comment_detail_path.format(self.plan_id, comment.pk))
         self.assertEqual(204, res.status_code)
@@ -34,12 +34,12 @@ class CommentTestCase(V1TestCase):
             Comment.objects.get(pk=comment.pk)
 
     def test_destroy_fail(self):
-        """DELETE /plan/plans/<id>/comments/<id>/: 存在しないコメントの削除テスト"""
+        """DELETE /plans/<id>/comments/<id>/: 存在しないコメントの削除テスト"""
         res = self.client.delete(self.comment_detail_path.format(self.plan_id, 9999))
         self.assertEqual(404, res.status_code)
 
     def test_get_detail(self):
-        """GET /plan/plans/<id>/comments/<id>/: コメントの詳細取得テスト"""
+        """GET /plans/<id>/comments/<id>/: コメントの詳細取得テスト"""
         comment = Comment.objects.create(user=self.user, plan_id=self.plan_id, **self.comment_data[0])
         res = self.client.get(self.comment_detail_path.format(self.plan_id, comment.pk), format="json")
         self.assertEqual(200, res.status_code)
@@ -47,7 +47,7 @@ class CommentTestCase(V1TestCase):
         self.assertEqual(self.user.username, res.data['user']['username'])
 
     def test_get_detail_404(self):
-        """GET /plan/plans/<id>/comments/<id>/: コメントの詳細取得404テスト"""
+        """GET /plans/<id>/comments/<id>/: コメントの詳細取得404テスト"""
         res = self.client.get(self.comment_detail_path.format(self.plan_id, 9999), data={}, format="json")
         self.assertEqual(404, res.status_code)
         new_plan_res = self.client.post(self.plan_path, data=self.plan_data, format='json')

--- a/src/plan/tests/test_nested_comment.py
+++ b/src/plan/tests/test_nested_comment.py
@@ -1,8 +1,8 @@
 from plan.models import Comment
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class CommentTestCase(BaseTestCase):
+class CommentTestCase(V1TestCase):
 
     def test_post(self):
         """POST /plan/plans/<id>/comments/: コメント作成テスト"""

--- a/src/plan/tests/test_nested_fav.py
+++ b/src/plan/tests/test_nested_fav.py
@@ -6,12 +6,12 @@ from .base import V1TestCase
 class FavTest(V1TestCase):
 
     def test_post(self):
-        """POST /plan/plans/<id>/favs/: いいね作成テスト"""
+        """POST /plans/<id>/favs/: いいね作成テスト"""
         res = self.client.post(self.fav_path.format(self.plan_res.data['pk']), data={}, format="json")
         self.assertEqual(201, res.status_code)
 
     def test_get_list(self):
-        """GET /plan/plans/<id>/favs/: いいね一覧取得テスト"""
+        """GET /plans/<id>/favs/: いいね一覧取得テスト"""
         plan_id = self.plan_id
         fav = Fav.objects.create(user=self.user, plan_id=plan_id)
         res = self.client.get(self.fav_path.format(plan_id), data={}, format="json")
@@ -25,7 +25,7 @@ class FavTest(V1TestCase):
         self.assertTrue(fav.pk in fav_list)
 
     def test_destroy(self):
-        """DELETE /plan/plans/<id>/favs/: いいね削除テスト"""
+        """DELETE /plans/<id>/favs/: いいね削除テスト"""
         fav = Fav.objects.create(user=self.user, plan_id=self.plan_id)
         res = self.client.delete(self.fav_me_path.format(self.plan_id))
         self.assertEqual(204, res.status_code)
@@ -33,19 +33,19 @@ class FavTest(V1TestCase):
             Fav.objects.get(pk=fav.pk)
 
     def test_destroy_fail(self):
-        """DELETE /plan/plans/<id>/favs/: 存在しないいいねの削除テスト"""
+        """DELETE /plans/<id>/favs/: 存在しないいいねの削除テスト"""
         res = self.client.delete(self.fav_me_path.format(self.plan_id))
         self.assertEqual(404, res.status_code)
 
     def test_get_detail(self):
-        """GET /plan/plans/<id>/favs/<id>/: いいねの詳細取得テスト"""
+        """GET /plans/<id>/favs/<id>/: いいねの詳細取得テスト"""
         fav = Fav.objects.create(user=self.user, plan_id=self.plan_res.data['pk'])
         res = self.client.get(self.fav_detail_path.format(self.plan_id, fav.pk), data={}, format="json")
         self.assertEqual(200, res.status_code)
         self.assertEqual(self.user.username, res.data['user']['username'])
 
     def test_get_detail_404(self):
-        """GET /plan/plans/<id>/favs/<id>/: いいねの詳細取得404テスト"""
+        """GET /plans/<id>/favs/<id>/: いいねの詳細取得404テスト"""
         res = self.client.get(self.fav_detail_path.format(self.plan_id, 9999), data={}, format="json")
         self.assertEqual(404, res.status_code)
         new_plan_res = self.client.post(self.plan_path, data=plan_data, format='json')

--- a/src/plan/tests/test_nested_fav.py
+++ b/src/plan/tests/test_nested_fav.py
@@ -1,9 +1,9 @@
 from plan.models import Fav
 from .data import plan_data
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class FavTest(BaseTestCase):
+class FavTest(V1TestCase):
 
     def test_post(self):
         """POST /plan/plans/<id>/favs/: いいね作成テスト"""

--- a/src/plan/tests/test_permission.py
+++ b/src/plan/tests/test_permission.py
@@ -5,7 +5,7 @@ from .base import V1TestCase
 class PermissionTest(V1TestCase):
 
     def test_plan_permission(self):
-        """POST /plan/plans/<id>/: 他人のPlanは更新不可であるかどうかのテスト"""
+        """POST /plans/<id>/: 他人のPlanは更新不可であるかどうかのテスト"""
         self._set_credentials(self.user)
         res = self.client.post(self.plan_path, data=self.plan_data, format='json')
         self.assertEqual(201, res.status_code)

--- a/src/plan/tests/test_permission.py
+++ b/src/plan/tests/test_permission.py
@@ -1,8 +1,8 @@
 from accounts.models import User
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class PermissionTest(BaseTestCase):
+class PermissionTest(V1TestCase):
 
     def test_plan_permission(self):
         """POST /plan/plans/<id>/: 他人のPlanは更新不可であるかどうかのテスト"""

--- a/src/plan/tests/test_plan.py
+++ b/src/plan/tests/test_plan.py
@@ -1,8 +1,8 @@
 from plan.models import Plan
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class PlanTest(BaseTestCase):
+class PlanTest(V1TestCase):
 
     def test_get(self):
         """GET /plan/plans/<id>/: Planの詳細を取得するテスト"""

--- a/src/plan/tests/test_plan.py
+++ b/src/plan/tests/test_plan.py
@@ -5,7 +5,7 @@ from .base import V1TestCase
 class PlanTest(V1TestCase):
 
     def test_get(self):
-        """GET /plan/plans/<id>/: Planの詳細を取得するテスト"""
+        """GET /plans/<id>/: Planの詳細を取得するテスト"""
         self.client.post(self.plan_path, data=self.plan_data, format='json')
         plan = Plan.objects.all()[0]
         res = self.client.get(self.plan_detail_path.format(plan.pk))

--- a/src/plan/tests/test_plan_list.py
+++ b/src/plan/tests/test_plan_list.py
@@ -1,5 +1,5 @@
 import copy
-from plan.models import Plan
+from plan.models import Plan, Fav
 from .base import V1TestCase
 
 
@@ -28,3 +28,11 @@ class PlanListTest(V1TestCase):
         self.assertEqual(400, res.status_code)
         plans = Plan.objects.all()
         self.assertEqual(1, plans.count())
+
+    def test_get_my_fav_plans(self):
+        """GET /me/favs/: 自分がふぁぼったPlan一覧が返されることを確認するテスト"""
+        Fav.objects.create(user=self.user, plan_id=self.plan_id)
+        res = self.client.get(self.my_fav_path)
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(1, len(res.data))
+        self.assertEqual(self.plan_id, res.data[0]['pk'])

--- a/src/plan/tests/test_plan_list.py
+++ b/src/plan/tests/test_plan_list.py
@@ -6,12 +6,12 @@ from .base import V1TestCase
 class PlanListTest(V1TestCase):
 
     def test_post(self):
-        """POST /plan/plans/: プラン作成テスト"""
+        """POST /plans/: プラン作成テスト"""
         res = self.client.post(self.plan_path, data=self.plan_data, format='json')
         self.assertEqual(201, res.status_code)
 
     def test_get(self):
-        """GET /plan/plans/: プラン取得テスト"""
+        """GET /plans/: プラン取得テスト"""
         self.client.post(self.plan_path, data=self.plan_data, format='json')
         new_data = copy.deepcopy(self.plan_data)
         new_data['name'] = "新しいコース"
@@ -21,7 +21,7 @@ class PlanListTest(V1TestCase):
         self.assertEqual(res.data[0]['name'], new_data['name'])
 
     def test_fail_post(self):
-        """POST /plan/plans/: 正しくない情報ではPlanが作成されないことを確認するテスト"""
+        """POST /plans/: 正しくない情報ではPlanが作成されないことを確認するテスト"""
         invalid_data = copy.deepcopy(self.plan_data)
         invalid_data['spots'] = []
         res = self.client.post(self.plan_path, data=invalid_data, format='json')

--- a/src/plan/tests/test_plan_list.py
+++ b/src/plan/tests/test_plan_list.py
@@ -1,9 +1,9 @@
 import copy
 from plan.models import Plan
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class PlanListTest(BaseTestCase):
+class PlanListTest(V1TestCase):
 
     def test_post(self):
         """POST /plan/plans/: プラン作成テスト"""

--- a/src/plan/tests/test_plan_list.py
+++ b/src/plan/tests/test_plan_list.py
@@ -1,5 +1,6 @@
 import copy
 from plan.models import Plan, Fav
+from accounts.models import User
 from .base import V1TestCase
 
 
@@ -33,6 +34,19 @@ class PlanListTest(V1TestCase):
         """GET /me/favs/: 自分がふぁぼったPlan一覧が返されることを確認するテスト"""
         Fav.objects.create(user=self.user, plan_id=self.plan_id)
         res = self.client.get(self.my_fav_path)
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(1, len(res.data))
+        self.assertEqual(self.plan_id, res.data[0]['pk'])
+
+    def test_get_specific_user_plans(self):
+        """GET /users/<id>/plans/: 特定のユーザの投稿したPlan一覧取得テスト"""
+        new_user = User.objects.create(**self.user_data[1], is_active=True)
+        self._set_credentials(new_user)
+        res = self.client.get(self.user_plan_path.format(new_user.pk))
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(0, len(res.data))
+        self._set_credentials(self.user)
+        res = self.client.get(self.user_plan_path.format(self.user.pk))
         self.assertEqual(200, res.status_code)
         self.assertEqual(1, len(res.data))
         self.assertEqual(self.plan_id, res.data[0]['pk'])

--- a/src/plan/tests/test_report.py
+++ b/src/plan/tests/test_report.py
@@ -1,10 +1,10 @@
 import copy
 from plan.models import Report
 from .data import img_file
-from .base import BaseTestCase
+from .base import V1TestCase
 
 
-class ReportTest(BaseTestCase):
+class ReportTest(V1TestCase):
 
     def test_post(self):
         """POST /plan/plans/<plan_id>/reports/ レポート作成テスト"""

--- a/src/plan/tests/test_report.py
+++ b/src/plan/tests/test_report.py
@@ -7,7 +7,7 @@ from .base import V1TestCase
 class ReportTest(V1TestCase):
 
     def test_post(self):
-        """POST /plan/plans/<plan_id>/reports/ レポート作成テスト"""
+        """POST /plans/<plan_id>/reports/ レポート作成テスト"""
         data = copy.deepcopy(self.report_data[0])
         data["plan_id"] = self.plan_id
         res = self.client.post(self.report_path.format(self.plan_id), data=data, format="json")
@@ -16,7 +16,7 @@ class ReportTest(V1TestCase):
         self.assertEqual(self.user.username, res.data['user']['username'])
 
     def test_multi_post(self):
-        """POST /plan/plans/<plan_id>/reports/ レポートを重複して作成するテスト"""
+        """POST /plans/<plan_id>/reports/ レポートを重複して作成するテスト"""
         for i in range(2):
             data = copy.deepcopy(self.report_data[i])
             data["plan_id"] = self.plan_id
@@ -26,21 +26,21 @@ class ReportTest(V1TestCase):
         self.assertEqual(2, len(reports))
 
     def test_get(self):
-        """GET /plan/plans/<plan_id>/reports/ レポートを取得するテスト"""
+        """GET /plans/<plan_id>/reports/ レポートを取得するテスト"""
         Report.objects.create(user=self.user, plan_id=self.plan_id, image=img_file)
         res = self.client.get(self.report_path.format(self.plan_id), format="json")
         self.assertEqual(200, res.status_code)
         self.assertEqual(1, len(res.data))
 
     def test_get_detail(self):
-        """GET /plan/plans/<plan_id>/reports/<report_id>/ レポート詳細を取得するテスト"""
+        """GET /plans/<plan_id>/reports/<report_id>/ レポート詳細を取得するテスト"""
         rep = Report.objects.create(user=self.user, plan_id=self.plan_id, image=img_file)
         res = self.client.get(self.report_detail_path.format(self.plan_id, rep.pk), format="json")
         self.assertEqual(200, res.status_code)
         self.assertEqual(self.user.username, res.data['user']['username'])
 
     def test_not_image(self):
-        """POST /plan/plans/<plan_id>/reports/ 画像情報無しでレポートをPOSTするとエラーが返ってくる"""
+        """POST /plans/<plan_id>/reports/ 画像情報無しでレポートをPOSTするとエラーが返ってくる"""
         res = self.client.post(self.report_path.format(self.plan_id), data={
             "plan_id": self.plan_id,
             "text": "test report",

--- a/src/plan/tests/test_users.py
+++ b/src/plan/tests/test_users.py
@@ -1,0 +1,16 @@
+from .base import V1TestCase
+
+
+class UsersTest(V1TestCase):
+
+    def test_create(self):
+        """ユーザ作成のテスト"""
+        test_user_data = {'username': 'test', 'password': 'hogefuga'}
+        res = self.client.post(self.user_path, data=test_user_data, format='json')
+        self.assertEqual(201, res.status_code)
+
+    def test_get(self):
+        """ユーザプロフィール取得テスト"""
+        res = self.client.get(self.user_detail_path.format(self.user.pk))
+        self.assertEqual(200, res.status_code)
+        self.assertEqual(self.user_data[0]['username'], res.data['username'])

--- a/src/plan/tests/test_users.py
+++ b/src/plan/tests/test_users.py
@@ -4,13 +4,13 @@ from .base import V1TestCase
 class UsersTest(V1TestCase):
 
     def test_create(self):
-        """ユーザ作成のテスト"""
+        """POST /users/: ユーザ作成のテスト"""
         test_user_data = {'username': 'test', 'password': 'hogefuga'}
         res = self.client.post(self.user_path, data=test_user_data, format='json')
         self.assertEqual(201, res.status_code)
 
     def test_get(self):
-        """ユーザプロフィール取得テスト"""
+        """GET /users/<id>/: ユーザプロフィール取得テスト"""
         res = self.client.get(self.user_detail_path.format(self.user.pk))
         self.assertEqual(200, res.status_code)
         self.assertEqual(self.user_data[0]['username'], res.data['username'])

--- a/src/plan/urls.py
+++ b/src/plan/urls.py
@@ -9,7 +9,6 @@ router.register(r'locations', views.LocationViewSets, base_name='locations')
 router.register(r'spots', views.SpotViewSets, base_name='spots')
 router.register(r'plans', views.PlanViewSets, base_name='plans')
 router.register(r'users', account_views.UserViewSets, base_name='users')
-router.register(r'me', account_views.MeViewSets, base_name='me')
 
 plan_nested_router = NestedDefaultRouter(router, r'plans', lookup='plan')
 plan_nested_router.register(r'favs', views.FavViewSets)
@@ -22,9 +21,9 @@ user_nested_router.register(r'plans', views.UserPlanView)
 
 app_name = 'plan'
 urlpatterns = [
+    path('me/', account_views.MeViewSet.as_view()),
     path('me/favs/', views.UserFavView.as_view({'get': 'list'})),
     path('me/plans/', views.UserPlanView.as_view({'get': 'list'})),
-    path('me/plans/<int:pk>', views.UserPlanView.as_view({'get': 'retrieve'})),
     path('', include(router.urls)),
     path('', include(plan_nested_router.urls)),
     path('', include(user_nested_router.urls)),

--- a/src/plan/urls.py
+++ b/src/plan/urls.py
@@ -9,6 +9,7 @@ router.register(r'locations', views.LocationViewSets, base_name='locations')
 router.register(r'spots', views.SpotViewSets, base_name='spots')
 router.register(r'plans', views.PlanViewSets, base_name='plans')
 router.register(r'users', account_views.UserViewSets, base_name='users')
+router.register(r'me', account_views.MeViewSets, base_name='me')
 
 plan_nested_router = NestedDefaultRouter(router, r'plans', lookup='plan')
 plan_nested_router.register(r'favs', views.FavViewSets)
@@ -21,6 +22,9 @@ user_nested_router.register(r'plans', views.UserPlanView)
 
 app_name = 'plan'
 urlpatterns = [
+    path('me/favs/', views.UserFavView.as_view({'get': 'list'})),
+    path('me/plans/', views.UserPlanView.as_view({'get': 'list'})),
+    path('me/plans/<int:pk>', views.UserPlanView.as_view({'get': 'retrieve'})),
     path('', include(router.urls)),
     path('', include(plan_nested_router.urls)),
     path('', include(user_nested_router.urls)),

--- a/src/plan/urls.py
+++ b/src/plan/urls.py
@@ -16,13 +16,12 @@ plan_nested_router.register(r'comments', views.CommentViewSets)
 plan_nested_router.register(r'reports', views.ReportViewSets)
 
 user_nested_router = NestedDefaultRouter(router, r'users', lookup='user')
-user_nested_router.register(r'favs', views.UserFavView)
 user_nested_router.register(r'plans', views.UserPlanView)
 
 app_name = 'plan'
 urlpatterns = [
     path('me/', account_views.MeViewSet.as_view()),
-    path('me/favs/', views.UserFavView.as_view({'get': 'list'})),
+    path('me/favs/', views.MyFavPlanView.as_view()),
     path('me/plans/', views.UserPlanView.as_view({'get': 'list'})),
     path('', include(router.urls)),
     path('', include(plan_nested_router.urls)),

--- a/src/plan/urls.py
+++ b/src/plan/urls.py
@@ -1,20 +1,27 @@
 from django.urls import path, include
 from rest_framework_nested.routers import DefaultRouter, NestedDefaultRouter
 from . import views
+from accounts import views as account_views
 
 
 router = DefaultRouter()
 router.register(r'locations', views.LocationViewSets, base_name='locations')
 router.register(r'spots', views.SpotViewSets, base_name='spots')
 router.register(r'plans', views.PlanViewSets, base_name='plans')
+router.register(r'users', account_views.UserViewSets, base_name='users')
 
 plan_nested_router = NestedDefaultRouter(router, r'plans', lookup='plan')
 plan_nested_router.register(r'favs', views.FavViewSets)
 plan_nested_router.register(r'comments', views.CommentViewSets)
 plan_nested_router.register(r'reports', views.ReportViewSets)
 
+user_nested_router = NestedDefaultRouter(router, r'users', lookup='user')
+user_nested_router.register(r'favs', views.UserFavView)
+user_nested_router.register(r'plans', views.UserPlanView)
+
 app_name = 'plan'
 urlpatterns = [
     path('', include(router.urls)),
-    path('', include(plan_nested_router.urls))
+    path('', include(plan_nested_router.urls)),
+    path('', include(user_nested_router.urls)),
 ]

--- a/src/plan/views.py
+++ b/src/plan/views.py
@@ -46,9 +46,9 @@ class ReportViewSets(viewsets.ModelViewSet):
     pagination_class = paginations.UnwrapPagination
 
 
-class FavViewSets(custom_mixins.NestedListMixin,
-                  custom_mixins.NestedDestroyMixin,
-                  custom_mixins.NestedRetrieveMixin,
+class FavViewSets(custom_mixins.PlanNestedListMixin,
+                  custom_mixins.PlanNestedDestroyMixin,
+                  custom_mixins.PlanNestedRetrieveMixin,
                   mixins.CreateModelMixin,
                   viewsets.GenericViewSet):
     """
@@ -92,9 +92,9 @@ class FavViewSets(custom_mixins.NestedListMixin,
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
 
-class CommentViewSets(custom_mixins.NestedListMixin,
-                      custom_mixins.NestedDestroyMixin,
-                      custom_mixins.NestedRetrieveMixin,
+class CommentViewSets(custom_mixins.PlanNestedListMixin,
+                      custom_mixins.PlanNestedDestroyMixin,
+                      custom_mixins.PlanNestedRetrieveMixin,
                       mixins.RetrieveModelMixin,
                       mixins.CreateModelMixin,
                       viewsets.GenericViewSet):
@@ -131,7 +131,7 @@ class PlanViewSets(mixins.CreateModelMixin,
                    mixins.RetrieveModelMixin,
                    mixins.UpdateModelMixin,
                    mixins.DestroyModelMixin,
-                   custom_mixins.NestedListMixin,
+                   custom_mixins.PlanNestedListMixin,
                    viewsets.GenericViewSet):
     """
     retrieve:
@@ -156,4 +156,43 @@ class PlanViewSets(mixins.CreateModelMixin,
     def list(self, request, *args, **kwargs):
         return super(PlanViewSets, self).list(
             request, serializer_class=serializers.AbstractPlanSerializer, *args, **kwargs
+        )
+
+
+class UserFavView(custom_mixins.UserNestedListMixin,
+                  viewsets.GenericViewSet):
+    """
+    指定したユーザのふぁぼに関するエンドポイント
+
+    list:
+        指定したユーザのふぁぼ一覧を返すエンドポイント
+    """
+    queryset = models.Fav.objects.all()
+    parser_classes = (JSONParser,)
+    serializer_class = serializers.FavSerializer
+    permission_classes = (IsAuthenticated,)
+    pagination_class = paginations.VersioningPagination
+
+
+class UserPlanView(custom_mixins.UserNestedListMixin,
+                   custom_mixins.UserNestedRetrieveMixin,
+                   viewsets.GenericViewSet):
+    """
+    指定したユーザのPlanについてのエンドポイント．
+
+    list:
+        指定したユーザが投稿したPlan一覧を返すエンドポイント
+
+    retrieve:
+        指定したユーザが投稿したPlanの詳細を返すエンドポイント
+    """
+    queryset = models.Plan.objects.all()
+    parser_classes = (JSONParser,)
+    serializer_class = serializers.PlanSerializer
+    permission_classes = (IsAuthenticated,)
+    pagination_class = paginations.VersioningPagination
+
+    def list(self, request, user_pk=None, serializer_class=None, **kwargs):
+        return super(UserPlanView, self).list(
+            request, user_pk=user_pk, serializer_class=serializers.AbstractPlanSerializer, **kwargs
         )

--- a/src/plan/views.py
+++ b/src/plan/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, status, mixins
+from rest_framework import viewsets, status, mixins, generics
 from rest_framework.decorators import action
 from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
@@ -175,24 +175,15 @@ class UserFavView(custom_mixins.UserNestedListMixin,
 
 
 class UserPlanView(custom_mixins.UserNestedListMixin,
-                   custom_mixins.UserNestedRetrieveMixin,
                    viewsets.GenericViewSet):
     """
     指定したユーザのPlanについてのエンドポイント．
 
     list:
         指定したユーザが投稿したPlan一覧を返すエンドポイント
-
-    retrieve:
-        指定したユーザが投稿したPlanの詳細を返すエンドポイント
     """
     queryset = models.Plan.objects.all()
     parser_classes = (JSONParser,)
-    serializer_class = serializers.PlanSerializer
+    serializer_class = serializers.AbstractPlanSerializer
     permission_classes = (IsAuthenticated,)
     pagination_class = paginations.VersioningPagination
-
-    def list(self, request, user_pk=None, serializer_class=None, **kwargs):
-        return super(UserPlanView, self).list(
-            request, user_pk=user_pk, serializer_class=serializers.AbstractPlanSerializer, **kwargs
-        )

--- a/src/plan/views.py
+++ b/src/plan/views.py
@@ -9,7 +9,6 @@ from . import (
     models,
     serializers,
     permissions,
-    paginations,
     mixins as custom_mixins,
 )
 
@@ -27,7 +26,6 @@ class LocationViewSets(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.LocationSerializer
     permission_classes = (IsAuthenticated,)
     filter_class = filters.LocationFilter
-    pagination_class = paginations.UnwrapPagination
 
 
 class SpotViewSets(viewsets.ModelViewSet):
@@ -35,7 +33,6 @@ class SpotViewSets(viewsets.ModelViewSet):
     parser_classes = (JSONParser,)
     serializer_class = serializers.SpotSerializer
     permission_classes = (IsAuthenticated, permissions.IsOwnerOrReadOnly)
-    pagination_class = paginations.UnwrapPagination
 
 
 class ReportViewSets(viewsets.ModelViewSet):
@@ -43,7 +40,6 @@ class ReportViewSets(viewsets.ModelViewSet):
     parser_classes = (JSONParser,)
     serializer_class = serializers.ReportSerializer
     permission_classes = (IsAuthenticated, permissions.IsOwnerOrReadOnly)
-    pagination_class = paginations.UnwrapPagination
 
 
 class FavViewSets(custom_mixins.PlanNestedListMixin,
@@ -70,7 +66,6 @@ class FavViewSets(custom_mixins.PlanNestedListMixin,
     parser_classes = (JSONParser,)
     serializer_class = serializers.FavSerializer
     permission_classes = (IsAuthenticated, permissions.IsOwnerOrReadOnly)
-    pagination_class = paginations.UnwrapPagination
 
     @action(methods=['post', 'delete'], detail=False, url_path='me')
     def me(self, request, plan_pk=None, **kwargs):
@@ -115,7 +110,6 @@ class CommentViewSets(custom_mixins.PlanNestedListMixin,
     parser_classes = (JSONParser,)
     serializer_class = serializers.CommentSerializer
     permission_classes = (IsAuthenticated, permissions.IsOwnerOrReadOnly)
-    pagination_class = paginations.UnwrapPagination
 
     def create(self, request, plan_pk=None, **kwargs):
         data = request.data
@@ -151,7 +145,6 @@ class PlanViewSets(mixins.CreateModelMixin,
     serializer_class = serializers.PlanSerializer
     permission_classes = (IsAuthenticated, permissions.IsOwnerOrReadOnly)
     filter_class = filters.PlanLocationFilter
-    pagination_class = paginations.UnwrapPagination
 
     def list(self, request, *args, **kwargs):
         return super(PlanViewSets, self).list(
@@ -170,7 +163,6 @@ class MyFavPlanView(generics.ListAPIView):
     parser_classes = (JSONParser,)
     serializer_class = serializers.PlanSerializer
     permission_classes = (IsAuthenticated,)
-    pagination_class = paginations.VersioningPagination
 
     def list(self, request, *args, **kwargs):
         queryset = self.get_queryset().filter(favs__user=self.request.user).all()
@@ -197,4 +189,3 @@ class UserPlanView(custom_mixins.UserNestedListMixin,
     parser_classes = (JSONParser,)
     serializer_class = serializers.AbstractPlanSerializer
     permission_classes = (IsAuthenticated,)
-    pagination_class = paginations.VersioningPagination


### PR DESCRIPTION
fix #114 

以下のエンドポイントを追加

- `/api/{version}/users/{user_pk}/`
    - GET
    - 指定したユーザのプロフィールを取得する
- `/api/{version}/users/`
    - POST
    - ユーザを作成する
- `/api/{version}/users/{user_pk}/plans/`
    - GET
    - 指定したユーザのプラン一覧を取得する
- `/api/{version}/me/`
    - GET, PUT, PATCH
    - 自分のプロフィールを取得・更新するエンドポイント
- `/api/{version}/me/plans/`
    - GET
    - 自分が投稿したプラン一覧を取得する
- `/api/{version}/me/favs/`
    - GET
    - 自分がふぁぼったプランの一覧を取得する